### PR TITLE
Replaced use-sync-set-state with use-chrome-storage

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -14,6 +14,7 @@
                 "react": "^18.2.0",
                 "react-dom": "^18.2.0",
                 "three": "^0.159.0",
+                "use-chrome-storage": "^1.2.2",
                 "use-sync-set-state": "^0.1.0",
                 "webextension-polyfill": "^0.10.0"
             },
@@ -15098,6 +15099,14 @@
             "license": "BSD-2-Clause",
             "dependencies": {
                 "punycode": "^2.1.0"
+            }
+        },
+        "node_modules/use-chrome-storage": {
+            "version": "1.2.2",
+            "resolved": "https://registry.npmjs.org/use-chrome-storage/-/use-chrome-storage-1.2.2.tgz",
+            "integrity": "sha512-/9xW7LWERd4q58n2oApAeOLKvqhGYEtcFXnU82Kcv9bCPeGF784zkm1dN9dJYXBZjdYQbLDHTwIvacagZDhjKQ==",
+            "peerDependencies": {
+                "react": "^16.9.0 || ^17.0.0 || ^18.0.0"
             }
         },
         "node_modules/use-sync-external-store": {

--- a/package.json
+++ b/package.json
@@ -74,6 +74,7 @@
         "react": "^18.2.0",
         "react-dom": "^18.2.0",
         "three": "^0.159.0",
+        "use-chrome-storage": "^1.2.2",
         "use-sync-set-state": "^0.1.0",
         "webextension-polyfill": "^0.10.0"
     }

--- a/src/backgroundPage.ts
+++ b/src/backgroundPage.ts
@@ -2,6 +2,8 @@ import browser, { Tabs } from "webextension-polyfill";
 import {START, SPACE} from "@src/helpers/constants";
 import {closeTab, doesTabExist, getCurrentTab, tabStreamCapture} from "@src/helpers/tabActions";
 import { getAppState, getTabMappings, removeTabMapping, setAppState, storeTabMapping } from "./helpers/tabMappingService";
+import { loadShaderList } from "./helpers/shaderActions";
+import { getStorage, setStorage } from "./helpers/storage";
 
 export const openShaderAmp = async (openerTabId?: number | undefined) => {
     // Fetch the current tab id in case it's not passed as a parameter
@@ -128,3 +130,17 @@ browser.commands.onCommand.addListener(async (command) => {
         await openShaderAmpOptions();
     }
 });
+
+const fetchShaderList = async () => {
+    const shaders = await loadShaderList();
+    await setStorage('shaderlist', shaders);
+    const storedShaderList = await getStorage('shaderlist');
+    console.log(`[ShaderAmp] Retrieved shaderlist, result: ${storedShaderList}\norig: ${shaders}`);
+}
+
+const initBackgroundPage = async () => {
+    console.log('[ShaderAmp] Initializing background worker...');
+    await fetchShaderList();
+}
+
+initBackgroundPage().catch(error => console.error(error));

--- a/src/content/index.tsx
+++ b/src/content/index.tsx
@@ -6,7 +6,7 @@ import { OrthographicCamera } from "@react-three/drei"
 import { getCurrentTab, getMediaStream } from "@src/helpers/tabActions";
 import { getContentTabInfo } from '@src/helpers/tabMappingService';
 import { AnalyzerMesh } from './AnalyzerMesh';
-import useSyncSetState from 'use-sync-set-state';
+import { useChromeStorageLocal } from 'use-chrome-storage';
 import "../css/app.css";
 import css from "./styles.module.css";
 
@@ -19,7 +19,7 @@ const App: React.FC = () => {
     //const orthoCamRef = useRef<OrthographicCamera>();
 
     // Synced states
-    const [shaderName] = useSyncSetState('shadername', 'MusicalHeart.frag');
+    const [shaderName] = useChromeStorageLocal('shadername', 'MusicalHeart.frag');
 
     const initializeAnalyzer = async () => {
         const currentTab = await getCurrentTab();

--- a/src/options/Options.tsx
+++ b/src/options/Options.tsx
@@ -1,7 +1,6 @@
 import { acquireVideoStream } from '@src/helpers/optionsActions';
 import React, { useEffect, useRef, useState } from 'react';
-import useSyncSetState from 'use-sync-set-state';
-import { loadShaderList } from "@src/helpers/shaderActions";
+import { useChromeStorageLocal } from 'use-chrome-storage';
 import '../css/app.css';
 import "./styles.module.css";
 
@@ -9,17 +8,12 @@ const Options: React.FC = () => {
     // Local states
     const videoElement = useRef<HTMLVideoElement>(null);
     const [videoStream, setVideoStream] = useState<MediaStream|undefined>();
-    const [shaderList, setShaderList] = useState<string[]>([]);
     const [shaderIndex, setShaderIndex] = useState<number>(0);
 
     // Synced states
-    const [shaderName, setShaderName] = useSyncSetState('shadername', 'MusicalHeart.frag');
-    const [showPreview, setShowPreview] = useSyncSetState('showpreview', false);
-
-    // Initial shader list retrieval
-    useEffect(() => {
-        fetchShaderList().catch(console.error);
-    }, []);
+    const [shaderName, setShaderName] = useChromeStorageLocal('shadername', 'MusicalHeart.frag');
+    const [showPreview, setShowPreview] = useChromeStorageLocal('showpreview', false);
+    const [shaderList] = useChromeStorageLocal('shaderlist', []);
 
     const cycleShaders = () => {
         if (shaderList.length == 0) {
@@ -29,11 +23,6 @@ const Options: React.FC = () => {
         setShaderName(newShaderName);
         const newShaderIndex = (shaderIndex + 1) % shaderList.length;
         setShaderIndex(newShaderIndex);
-    }
-
-    const fetchShaderList = async () => {
-        const shaders = await loadShaderList();
-        setShaderList(shaders);
     }
 
     const handleShowPreviewInput = (event:any) => {

--- a/yarn.lock
+++ b/yarn.lock
@@ -5734,7 +5734,7 @@ react-use-measure@^2.1.1:
   dependencies:
     debounce "^1.2.1"
 
-"react@^15.0.0 || ^16.0.0 || ^17.0.0 || ^18.0.0", "react@^16.0.0 || ^17.0.0 || ^18.0.0", "react@^16.8.0 || ^17.0.0 || ^18.0.0", react@^18.0.0, react@^18.2.0, "react@>= 16.8.0", react@>=16, react@>=16.13, react@>=16.8, react@>=17.0, react@>=18.0:
+"react@^15.0.0 || ^16.0.0 || ^17.0.0 || ^18.0.0", "react@^16.0.0 || ^17.0.0 || ^18.0.0", "react@^16.8.0 || ^17.0.0 || ^18.0.0", "react@^16.9.0 || ^17.0.0 || ^18.0.0", react@^18.0.0, react@^18.2.0, "react@>= 16.8.0", react@>=16, react@>=16.13, react@>=16.8, react@>=17.0, react@>=18.0:
   version "18.2.0"
   resolved "https://registry.npmjs.org/react/-/react-18.2.0.tgz"
   integrity sha512-/3IjMdb2L9QbBdWiW5e3P2/npwMBaU9mHCSCUzNln0ZCYbcfTsGbTJrU/kGemdH2IWmB2ioZ+zkxtmq6g09fGQ==
@@ -6691,6 +6691,11 @@ uri-js@^4.2.2:
   integrity sha512-7rKUyy33Q1yc98pQ1DAmLtwX109F7TIfWlW1Ydo8Wl1ii1SeHieeh0HHfPeL2fMXK6z0s8ecKs9frCuLJvndBg==
   dependencies:
     punycode "^2.1.0"
+
+use-chrome-storage@^1.2.2:
+  version "1.2.2"
+  resolved "https://registry.npmjs.org/use-chrome-storage/-/use-chrome-storage-1.2.2.tgz"
+  integrity sha512-/9xW7LWERd4q58n2oApAeOLKvqhGYEtcFXnU82Kcv9bCPeGF784zkm1dN9dJYXBZjdYQbLDHTwIvacagZDhjKQ==
 
 use-sync-external-store@1.2.0:
   version "1.2.0"


### PR DESCRIPTION
And centralized the shaderlist fetching to the background page

`use-chrome-storage` does the same thing as `use-sync-set-state` but actually uses Chrome's Storage back-end. This means we can use it in our background page as well.

Check out;
https://github.com/onikienko/use-chrome-storage
