### PR TITLE
Adding shaderlist polling

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -15,7 +15,8 @@
                 "react": "^18.2.0",
                 "react-dom": "^18.2.0",
                 "three": "^0.159.0",
-                "webextension-polyfill": "^0.10.0"
+                "webextension-polyfill": "^0.10.0",
+                "webpack-shell-plugin-next": "^2.3.1"
             },
             "devDependencies": {
                 "@babel/core": "^7.23.2",
@@ -4347,7 +4348,6 @@
             "version": "0.3.3",
             "resolved": "https://registry.npmjs.org/@jridgewell/gen-mapping/-/gen-mapping-0.3.3.tgz",
             "integrity": "sha512-HLhSWOLRi875zjjMG/r+Nv0oCW8umGb0BgEhyX3dDX3egwZtB8PqLnjz3yedt8R5StBrzcg4aBpnh8UA9D1BoQ==",
-            "dev": true,
             "license": "MIT",
             "dependencies": {
                 "@jridgewell/set-array": "^1.0.1",
@@ -4362,7 +4362,6 @@
             "version": "3.1.1",
             "resolved": "https://registry.npmjs.org/@jridgewell/resolve-uri/-/resolve-uri-3.1.1.tgz",
             "integrity": "sha512-dSYZh7HhCDtCKm4QakX0xFpsRDqjjtZf/kjI/v3T3Nwt5r8/qz/M19F9ySyOqU94SXBmeG9ttTul+YnR4LOxFA==",
-            "dev": true,
             "license": "MIT",
             "engines": {
                 "node": ">=6.0.0"
@@ -4372,7 +4371,6 @@
             "version": "1.1.2",
             "resolved": "https://registry.npmjs.org/@jridgewell/set-array/-/set-array-1.1.2.tgz",
             "integrity": "sha512-xnkseuNADM0gt2bs+BvhO0p78Mk762YnZdsuzFV018NoG1Sj1SCQvpSqa7XUaTam5vAGasABV9qXASMKnFMwMw==",
-            "dev": true,
             "license": "MIT",
             "engines": {
                 "node": ">=6.0.0"
@@ -4382,7 +4380,6 @@
             "version": "0.3.5",
             "resolved": "https://registry.npmjs.org/@jridgewell/source-map/-/source-map-0.3.5.tgz",
             "integrity": "sha512-UTYAUj/wviwdsMfzoSJspJxbkH5o1snzwX0//0ENX1u/55kkZZkcTZP6u9bwKGkv+dkk9at4m1Cpt0uY80kcpQ==",
-            "dev": true,
             "license": "MIT",
             "dependencies": {
                 "@jridgewell/gen-mapping": "^0.3.0",
@@ -4393,14 +4390,12 @@
             "version": "1.4.15",
             "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.4.15.tgz",
             "integrity": "sha512-eF2rxCRulEKXHTRiDrDy6erMYWqNw4LPdQ8UQA4huuxaQsVeRPFl2oM8oDGxMFhJUWZf9McpLtJasDDZb/Bpeg==",
-            "dev": true,
             "license": "MIT"
         },
         "node_modules/@jridgewell/trace-mapping": {
             "version": "0.3.20",
             "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.20.tgz",
             "integrity": "sha512-R8LcPeWZol2zR8mmH3JeKQ6QRCFb7XgUhV9ZlGhHLGyg4wpPiPZNQOOWhFZhxKw8u//yTbNGI42Bx/3paXEQ+Q==",
-            "dev": true,
             "license": "MIT",
             "dependencies": {
                 "@jridgewell/resolve-uri": "^3.1.0",
@@ -4740,7 +4735,6 @@
             "version": "8.2.1",
             "resolved": "https://registry.npmjs.org/@types/eslint/-/eslint-8.2.1.tgz",
             "integrity": "sha512-UP9rzNn/XyGwb5RQ2fok+DzcIRIYwc16qTXse5+Smsy8MOIccCChT15KAwnsgQx4PzJkaMq4myFyZ4CL5TjhIQ==",
-            "dev": true,
             "license": "MIT",
             "dependencies": {
                 "@types/estree": "*",
@@ -4751,7 +4745,6 @@
             "version": "3.7.4",
             "resolved": "https://registry.npmjs.org/@types/eslint-scope/-/eslint-scope-3.7.4.tgz",
             "integrity": "sha512-9K4zoImiZc3HlIp6AVUDE4CWYx22a+lhSZMYNpbjW04+YF0KWj4pJXnEMjdnFTiQibFFmElcsasJXDbdI/EPhA==",
-            "dev": true,
             "license": "MIT",
             "dependencies": {
                 "@types/eslint": "*",
@@ -4762,7 +4755,6 @@
             "version": "0.0.51",
             "resolved": "https://registry.npmjs.org/@types/estree/-/estree-0.0.51.tgz",
             "integrity": "sha512-CuPgU6f3eT/XgKKPqKd/gLZV1Xmvf1a2R5POBOGQa6uv82xpls89HU5zKeVoyR8XzHd1RGNOlQlvUe3CFkjWNQ==",
-            "dev": true,
             "license": "MIT"
         },
         "node_modules/@types/filesystem": {
@@ -4841,14 +4833,12 @@
             "version": "7.0.9",
             "resolved": "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.9.tgz",
             "integrity": "sha512-qcUXuemtEu+E5wZSJHNxUXeCZhAfXKQ41D+duX+VYPde7xyEVZci+/oXKJL13tnRs9lR2pr4fod59GT6/X1/yQ==",
-            "dev": true,
             "license": "MIT"
         },
         "node_modules/@types/node": {
             "version": "20.10.5",
             "resolved": "https://registry.npmjs.org/@types/node/-/node-20.10.5.tgz",
             "integrity": "sha512-nNPsNE65wjMxEKI93yOP+NPGGBJz/PoN3kZsVLee0XMiJolxSekEVD8wRwBUBqkwc7UWop0edW50yrCQW4CyRw==",
-            "dev": true,
             "dependencies": {
                 "undici-types": "~5.26.4"
             }
@@ -5411,7 +5401,6 @@
             "version": "1.11.6",
             "resolved": "https://registry.npmjs.org/@webassemblyjs/ast/-/ast-1.11.6.tgz",
             "integrity": "sha512-IN1xI7PwOvLPgjcf180gC1bqn3q/QaOCwYUahIOhbYUu8KA/3tw2RT/T0Gidi1l7Hhj5D/INhJxiICObqpMu4Q==",
-            "dev": true,
             "license": "MIT",
             "dependencies": {
                 "@webassemblyjs/helper-numbers": "1.11.6",
@@ -5422,28 +5411,24 @@
             "version": "1.11.6",
             "resolved": "https://registry.npmjs.org/@webassemblyjs/floating-point-hex-parser/-/floating-point-hex-parser-1.11.6.tgz",
             "integrity": "sha512-ejAj9hfRJ2XMsNHk/v6Fu2dGS+i4UaXBXGemOfQ/JfQ6mdQg/WXtwleQRLLS4OvfDhv8rYnVwH27YJLMyYsxhw==",
-            "dev": true,
             "license": "MIT"
         },
         "node_modules/@webassemblyjs/helper-api-error": {
             "version": "1.11.6",
             "resolved": "https://registry.npmjs.org/@webassemblyjs/helper-api-error/-/helper-api-error-1.11.6.tgz",
             "integrity": "sha512-o0YkoP4pVu4rN8aTJgAyj9hC2Sv5UlkzCHhxqWj8butaLvnpdc2jOwh4ewE6CX0txSfLn/UYaV/pheS2Txg//Q==",
-            "dev": true,
             "license": "MIT"
         },
         "node_modules/@webassemblyjs/helper-buffer": {
             "version": "1.11.6",
             "resolved": "https://registry.npmjs.org/@webassemblyjs/helper-buffer/-/helper-buffer-1.11.6.tgz",
             "integrity": "sha512-z3nFzdcp1mb8nEOFFk8DrYLpHvhKC3grJD2ardfKOzmbmJvEf/tPIqCY+sNcwZIY8ZD7IkB2l7/pqhUhqm7hLA==",
-            "dev": true,
             "license": "MIT"
         },
         "node_modules/@webassemblyjs/helper-numbers": {
             "version": "1.11.6",
             "resolved": "https://registry.npmjs.org/@webassemblyjs/helper-numbers/-/helper-numbers-1.11.6.tgz",
             "integrity": "sha512-vUIhZ8LZoIWHBohiEObxVm6hwP034jwmc9kuq5GdHZH0wiLVLIPcMCdpJzG4C11cHoQ25TFIQj9kaVADVX7N3g==",
-            "dev": true,
             "license": "MIT",
             "dependencies": {
                 "@webassemblyjs/floating-point-hex-parser": "1.11.6",
@@ -5455,14 +5440,12 @@
             "version": "1.11.6",
             "resolved": "https://registry.npmjs.org/@webassemblyjs/helper-wasm-bytecode/-/helper-wasm-bytecode-1.11.6.tgz",
             "integrity": "sha512-sFFHKwcmBprO9e7Icf0+gddyWYDViL8bpPjJJl0WHxCdETktXdmtWLGVzoHbqUcY4Be1LkNfwTmXOJUFZYSJdA==",
-            "dev": true,
             "license": "MIT"
         },
         "node_modules/@webassemblyjs/helper-wasm-section": {
             "version": "1.11.6",
             "resolved": "https://registry.npmjs.org/@webassemblyjs/helper-wasm-section/-/helper-wasm-section-1.11.6.tgz",
             "integrity": "sha512-LPpZbSOwTpEC2cgn4hTydySy1Ke+XEu+ETXuoyvuyezHO3Kjdu90KK95Sh9xTbmjrCsUwvWwCOQQNta37VrS9g==",
-            "dev": true,
             "license": "MIT",
             "dependencies": {
                 "@webassemblyjs/ast": "1.11.6",
@@ -5475,7 +5458,6 @@
             "version": "1.11.6",
             "resolved": "https://registry.npmjs.org/@webassemblyjs/ieee754/-/ieee754-1.11.6.tgz",
             "integrity": "sha512-LM4p2csPNvbij6U1f19v6WR56QZ8JcHg3QIJTlSwzFcmx6WSORicYj6I63f9yU1kEUtrpG+kjkiIAkevHpDXrg==",
-            "dev": true,
             "license": "MIT",
             "dependencies": {
                 "@xtuc/ieee754": "^1.2.0"
@@ -5485,7 +5467,6 @@
             "version": "1.11.6",
             "resolved": "https://registry.npmjs.org/@webassemblyjs/leb128/-/leb128-1.11.6.tgz",
             "integrity": "sha512-m7a0FhE67DQXgouf1tbN5XQcdWoNgaAuoULHIfGFIEVKA6tu/edls6XnIlkmS6FrXAquJRPni3ZZKjw6FSPjPQ==",
-            "dev": true,
             "license": "Apache-2.0",
             "dependencies": {
                 "@xtuc/long": "4.2.2"
@@ -5495,14 +5476,12 @@
             "version": "1.11.6",
             "resolved": "https://registry.npmjs.org/@webassemblyjs/utf8/-/utf8-1.11.6.tgz",
             "integrity": "sha512-vtXf2wTQ3+up9Zsg8sa2yWiQpzSsMyXj0qViVP6xKGCUT8p8YJ6HqI7l5eCnWx1T/FYdsv07HQs2wTFbbof/RA==",
-            "dev": true,
             "license": "MIT"
         },
         "node_modules/@webassemblyjs/wasm-edit": {
             "version": "1.11.6",
             "resolved": "https://registry.npmjs.org/@webassemblyjs/wasm-edit/-/wasm-edit-1.11.6.tgz",
             "integrity": "sha512-Ybn2I6fnfIGuCR+Faaz7YcvtBKxvoLV3Lebn1tM4o/IAJzmi9AWYIPWpyBfU8cC+JxAO57bk4+zdsTjJR+VTOw==",
-            "dev": true,
             "license": "MIT",
             "dependencies": {
                 "@webassemblyjs/ast": "1.11.6",
@@ -5519,7 +5498,6 @@
             "version": "1.11.6",
             "resolved": "https://registry.npmjs.org/@webassemblyjs/wasm-gen/-/wasm-gen-1.11.6.tgz",
             "integrity": "sha512-3XOqkZP/y6B4F0PBAXvI1/bky7GryoogUtfwExeP/v7Nzwo1QLcq5oQmpKlftZLbT+ERUOAZVQjuNVak6UXjPA==",
-            "dev": true,
             "license": "MIT",
             "dependencies": {
                 "@webassemblyjs/ast": "1.11.6",
@@ -5533,7 +5511,6 @@
             "version": "1.11.6",
             "resolved": "https://registry.npmjs.org/@webassemblyjs/wasm-opt/-/wasm-opt-1.11.6.tgz",
             "integrity": "sha512-cOrKuLRE7PCe6AsOVl7WasYf3wbSo4CeOk6PkrjS7g57MFfVUF9u6ysQBBODX0LdgSvQqRiGz3CXvIDKcPNy4g==",
-            "dev": true,
             "license": "MIT",
             "dependencies": {
                 "@webassemblyjs/ast": "1.11.6",
@@ -5546,7 +5523,6 @@
             "version": "1.11.6",
             "resolved": "https://registry.npmjs.org/@webassemblyjs/wasm-parser/-/wasm-parser-1.11.6.tgz",
             "integrity": "sha512-6ZwPeGzMJM3Dqp3hCsLgESxBGtT/OeCvCZ4TA1JUPYgmhAx38tTPR9JaKy0S5H3evQpO/h2uWs2j6Yc/fjkpTQ==",
-            "dev": true,
             "license": "MIT",
             "dependencies": {
                 "@webassemblyjs/ast": "1.11.6",
@@ -5561,7 +5537,6 @@
             "version": "1.11.6",
             "resolved": "https://registry.npmjs.org/@webassemblyjs/wast-printer/-/wast-printer-1.11.6.tgz",
             "integrity": "sha512-JM7AhRcE+yW2GWYaKeHL5vt4xqee5N2WcezptmgyhNS+ScggqcT1OtXykhAb13Sn5Yas0j2uv9tHgrjwvzAP4A==",
-            "dev": true,
             "license": "MIT",
             "dependencies": {
                 "@webassemblyjs/ast": "1.11.6",
@@ -5619,21 +5594,18 @@
             "version": "1.2.0",
             "resolved": "https://registry.npmjs.org/@xtuc/ieee754/-/ieee754-1.2.0.tgz",
             "integrity": "sha512-DX8nKgqcGwsc0eJSqYt5lwP4DH5FlHnmuWWBRy7X0NcaGR0ZtuyeESgMwTYVEtxmsNGY+qit4QYT/MIYTOTPeA==",
-            "dev": true,
             "license": "BSD-3-Clause"
         },
         "node_modules/@xtuc/long": {
             "version": "4.2.2",
             "resolved": "https://registry.npmjs.org/@xtuc/long/-/long-4.2.2.tgz",
             "integrity": "sha512-NuHqBY1PB/D8xU6s/thBgOAiAP7HOYDQ32+BFZILJ8ivkUkAHQnWfn6WhL79Owj1qmUnoN/YPhktdIoucipkAQ==",
-            "dev": true,
             "license": "Apache-2.0"
         },
         "node_modules/acorn": {
             "version": "8.11.2",
             "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.11.2.tgz",
             "integrity": "sha512-nc0Axzp/0FILLEVsm4fNwLCwMttvhEI263QtVPQcbpfZZ3ts0hLsZGOpE6czNlid7CJ9MlyH8reXkpsf3YUY4w==",
-            "dev": true,
             "license": "MIT",
             "bin": {
                 "acorn": "bin/acorn"
@@ -5656,7 +5628,6 @@
             "version": "6.12.6",
             "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.12.6.tgz",
             "integrity": "sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g==",
-            "dev": true,
             "license": "MIT",
             "dependencies": {
                 "fast-deep-equal": "^3.1.1",
@@ -5673,7 +5644,6 @@
             "version": "3.5.2",
             "resolved": "https://registry.npmjs.org/ajv-keywords/-/ajv-keywords-3.5.2.tgz",
             "integrity": "sha512-5p6WTN0DdTGVQk6VjcEju19IgaHudalcfabD7yhDGeA6bcQnmL+CpveLJq/3hvfwd1aof6L386Ougkx6RfyMIQ==",
-            "dev": true,
             "license": "MIT",
             "peerDependencies": {
                 "ajv": "^6.9.1"
@@ -6718,7 +6688,6 @@
             "version": "1.1.2",
             "resolved": "https://registry.npmjs.org/buffer-from/-/buffer-from-1.1.2.tgz",
             "integrity": "sha512-E+XQCRwSbaaiChtv6k6Dwgc+bx+Bs6vuKJHHl5kox/BaKbhiXzqQOwK4cO22yElGp2OCmjwVhT3HmxgyPGnJfQ==",
-            "dev": true,
             "license": "MIT"
         },
         "node_modules/bundle-name": {
@@ -6884,7 +6853,6 @@
             "version": "1.0.3",
             "resolved": "https://registry.npmjs.org/chrome-trace-event/-/chrome-trace-event-1.0.3.tgz",
             "integrity": "sha512-p3KULyQg4S7NIHixdwbGX+nFHkoBiA4YQmyWtjb8XngSKV124nJmRysgAeujbUVb15vh+RvFUfCPqU7rXk+hZg==",
-            "dev": true,
             "license": "MIT",
             "engines": {
                 "node": ">=6.0"
@@ -7575,7 +7543,6 @@
             "version": "5.15.0",
             "resolved": "https://registry.npmjs.org/enhanced-resolve/-/enhanced-resolve-5.15.0.tgz",
             "integrity": "sha512-LXYT42KJ7lpIKECr2mAXIaMldcNCh/7E0KBKOu4KSfkHmP+mZmSs+8V5gBAqisWBy0OO4W5Oyys0GO1Y8KtdKg==",
-            "dev": true,
             "license": "MIT",
             "dependencies": {
                 "graceful-fs": "^4.2.4",
@@ -7782,7 +7749,6 @@
             "version": "1.3.1",
             "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-1.3.1.tgz",
             "integrity": "sha512-JUFAyicQV9mXc3YRxPnDlrfBKpqt6hUYzz9/boprUJHs4e4KVr3XwOF70doO6gwXUor6EWZJAyWAfKki84t20Q==",
-            "dev": true,
             "license": "MIT"
         },
         "node_modules/es-set-tostringtag": {
@@ -7832,7 +7798,6 @@
             "version": "3.1.1",
             "resolved": "https://registry.npmjs.org/escalade/-/escalade-3.1.1.tgz",
             "integrity": "sha512-k0er2gUkLf8O0zKJiAhmkTnJlTvINGv7ygDNPbeIsX/TJjGJZHuh9B2UxbsaEkmlEo9MfhrSzmhIlhRlI2GXnw==",
-            "dev": true,
             "license": "MIT",
             "engines": {
                 "node": ">=6"
@@ -8013,7 +7978,6 @@
             "version": "5.1.1",
             "resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-5.1.1.tgz",
             "integrity": "sha512-2NxwbF/hZ0KpepYN0cNbo+FN6XoK7GaHlQhgx/hIZl6Va0bF45RQOOwhLIy8lQDbuCiadSLCBnH2CFYquit5bw==",
-            "dev": true,
             "license": "BSD-2-Clause",
             "dependencies": {
                 "esrecurse": "^4.3.0",
@@ -8027,7 +7991,6 @@
             "version": "4.3.0",
             "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-4.3.0.tgz",
             "integrity": "sha512-39nnKffWz8xN1BU/2c79n9nB9HDzo0niYUqx6xyqUnyoAnQyyWpOTdZEeiCch8BBu515t4wp9ZmgVfVhn9EBpw==",
-            "dev": true,
             "license": "BSD-2-Clause",
             "engines": {
                 "node": ">=4.0"
@@ -8247,7 +8210,6 @@
             "version": "4.3.0",
             "resolved": "https://registry.npmjs.org/esrecurse/-/esrecurse-4.3.0.tgz",
             "integrity": "sha512-KmfKL3b6G+RXvP8N1vr3Tq1kL/oCFgn2NYXEtqP8/L3pKapUA4G8cFVaoF3SU323CD4XypR/ffioHmkti6/Tag==",
-            "dev": true,
             "license": "BSD-2-Clause",
             "dependencies": {
                 "estraverse": "^5.2.0"
@@ -8260,7 +8222,6 @@
             "version": "5.3.0",
             "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-5.3.0.tgz",
             "integrity": "sha512-MMdARuVEQziNTeJD8DgMqmhwR11BRQ/cBP+pLtYdSTnf3MIO8fFeiINEbX36ZdNlfU/7A9f3gUw49B3oQsvwBA==",
-            "dev": true,
             "license": "BSD-2-Clause",
             "engines": {
                 "node": ">=4.0"
@@ -8280,7 +8241,6 @@
             "version": "3.3.0",
             "resolved": "https://registry.npmjs.org/events/-/events-3.3.0.tgz",
             "integrity": "sha512-mQw+2fkQbALzQ7V0MY0IqdnXNOeTtP4r0lN9z7AAawCXgqea7bDii20AYrIBrFd/Hx0M2Ocz6S111CaFkUcb0Q==",
-            "dev": true,
             "license": "MIT",
             "engines": {
                 "node": ">=0.8.x"
@@ -8347,7 +8307,6 @@
             "version": "3.1.3",
             "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
             "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==",
-            "dev": true,
             "license": "MIT"
         },
         "node_modules/fast-diff": {
@@ -8378,7 +8337,6 @@
             "version": "2.1.0",
             "resolved": "https://registry.npmjs.org/fast-json-stable-stringify/-/fast-json-stable-stringify-2.1.0.tgz",
             "integrity": "sha512-lhd/wF+Lk98HZoTCtlVraHtfh5XYijIjalXck7saUtuanSDyLMxnHhSXEDJqHxD7msR8D0uCmqlkwjCV8xvwHw==",
-            "dev": true,
             "license": "MIT"
         },
         "node_modules/fast-levenshtein": {
@@ -8858,7 +8816,6 @@
             "version": "0.4.1",
             "resolved": "https://registry.npmjs.org/glob-to-regexp/-/glob-to-regexp-0.4.1.tgz",
             "integrity": "sha512-lkX1HJXwyMcprw/5YUZc2s7DrpAiHB21/V+E1rHUrVNokkvB6bqMzT0VfV6/86ZNabt1k14YOIaT7nDvOX3Iiw==",
-            "dev": true,
             "license": "BSD-2-Clause"
         },
         "node_modules/globals": {
@@ -8943,7 +8900,6 @@
             "version": "4.2.10",
             "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.10.tgz",
             "integrity": "sha512-9ByhssR2fPVsNZj478qUUbKfmL0+t5BDVyjShtyZZLiK7ZDAArFFfopyOTj0M05wE2tJPisA4iTnnXl2YoPvOA==",
-            "dev": true,
             "license": "ISC"
         },
         "node_modules/graphemer": {
@@ -9008,7 +8964,6 @@
             "version": "4.0.0",
             "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
             "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
-            "dev": true,
             "license": "MIT",
             "engines": {
                 "node": ">=8"
@@ -11551,14 +11506,12 @@
             "version": "2.3.1",
             "resolved": "https://registry.npmjs.org/json-parse-even-better-errors/-/json-parse-even-better-errors-2.3.1.tgz",
             "integrity": "sha512-xyFwyhro/JEof6Ghe2iz2NcXoj2sloNsWr/XsERDK/oiPCfaNhl5ONfp+jQdAZRQQ0IJWNzH9zIZF7li91kh2w==",
-            "dev": true,
             "license": "MIT"
         },
         "node_modules/json-schema-traverse": {
             "version": "0.4.1",
             "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
             "integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==",
-            "dev": true,
             "license": "MIT"
         },
         "node_modules/json-stable-stringify-without-jsonify": {
@@ -11835,7 +11788,6 @@
             "version": "4.2.0",
             "resolved": "https://registry.npmjs.org/loader-runner/-/loader-runner-4.2.0.tgz",
             "integrity": "sha512-92+huvxMvYlMzMt0iIOukcwYBFpkYJdpl2xsZ7LrlayO7E8SOv+JJUEK17B/dJIHAOLMfh2dZZ/Y18WgmGtYNw==",
-            "dev": true,
             "license": "MIT",
             "engines": {
                 "node": ">=6.11.5"
@@ -11950,7 +11902,6 @@
             "version": "2.0.0",
             "resolved": "https://registry.npmjs.org/merge-stream/-/merge-stream-2.0.0.tgz",
             "integrity": "sha512-abv/qOcuPfk3URPfDzmZU1LKmuw8kT+0nIHvKrKgFrwifol/doWcdA4ZqsWQ8ENrFKkd67Mfpo/LovbIUsbt3w==",
-            "dev": true,
             "license": "MIT"
         },
         "node_modules/merge2": {
@@ -11994,7 +11945,6 @@
             "version": "1.51.0",
             "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.51.0.tgz",
             "integrity": "sha512-5y8A56jg7XVQx2mbv1lu49NR4dokRnhZYTtL+KGfaa27uq4pSTXkwQkFJl4pkRMyNFz/EtYDSkiiEHx3F7UN6g==",
-            "dev": true,
             "license": "MIT",
             "engines": {
                 "node": ">= 0.6"
@@ -12004,7 +11954,6 @@
             "version": "2.1.34",
             "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.34.tgz",
             "integrity": "sha512-6cP692WwGIs9XXdOO4++N+7qjqv0rqxxVvJ3VHPh/Sc9mVZcQP+ZGhkKiTvWMQRr2tbHkJP/Yn7Y0npb3ZBs4A==",
-            "dev": true,
             "license": "MIT",
             "dependencies": {
                 "mime-db": "1.51.0"
@@ -12105,7 +12054,6 @@
             "version": "2.6.2",
             "resolved": "https://registry.npmjs.org/neo-async/-/neo-async-2.6.2.tgz",
             "integrity": "sha512-Yd3UES5mWCSqR+qNT93S3UoYUkqAZ9lLg8a7g9rimsWmYGK8cVToA4/sF3RrshdyV3sAGMXVUmpMYOw+dLpOuw==",
-            "dev": true,
             "license": "MIT"
         },
         "node_modules/node-int64": {
@@ -12590,7 +12538,6 @@
             "version": "1.0.0",
             "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.0.0.tgz",
             "integrity": "sha512-1fygroTLlHu66zi26VoTDv8yRgm0Fccecssto+MhsZ0D/DGW2sm8E8AjW7NU5VVTRt5GxbeZ5qBuJr+HyLYkjQ==",
-            "dev": true,
             "license": "ISC"
         },
         "node_modules/picomatch": {
@@ -13061,7 +13008,6 @@
             "version": "2.1.1",
             "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.1.1.tgz",
             "integrity": "sha512-XRsRjdf+j5ml+y/6GKHPZbrF/8p2Yga0JPtdqTIY2Xe5ohJPD9saDJJLPvp9+NSBprVvevdXZybnj2cv8OEd0A==",
-            "dev": true,
             "license": "MIT",
             "engines": {
                 "node": ">=6"
@@ -13109,7 +13055,6 @@
             "version": "2.1.0",
             "resolved": "https://registry.npmjs.org/randombytes/-/randombytes-2.1.0.tgz",
             "integrity": "sha512-vYl3iOX+4CKUWuxGi9Ukhie6fsqXqS9FE2Zaic4tNFD2N2QQaXOMFbuKK4QmDHC0JO6B1Zp41J0LpT0oR68amQ==",
-            "dev": true,
             "license": "MIT",
             "dependencies": {
                 "safe-buffer": "^5.1.0"
@@ -13119,7 +13064,6 @@
             "version": "5.2.1",
             "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
             "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==",
-            "dev": true,
             "funding": [
                 {
                     "type": "github",
@@ -13624,7 +13568,6 @@
             "version": "3.3.0",
             "resolved": "https://registry.npmjs.org/schema-utils/-/schema-utils-3.3.0.tgz",
             "integrity": "sha512-pN/yOAvcC+5rQ5nERGuwrjLlYvLTbCibnZ1I7B1LaiAz9BRBlE9GMgE/eqV30P7aJQUf7Ddimy/RsbYO/GrVGg==",
-            "dev": true,
             "license": "MIT",
             "dependencies": {
                 "@types/json-schema": "^7.0.8",
@@ -13653,7 +13596,6 @@
             "version": "6.0.1",
             "resolved": "https://registry.npmjs.org/serialize-javascript/-/serialize-javascript-6.0.1.tgz",
             "integrity": "sha512-owoXEFjWRllis8/M1Q+Cw5k8ZH40e3zhp/ovX+Xr/vi1qj6QesbyXXViFbpNvWvPNAD62SutwEXavefrLJWj7w==",
-            "dev": true,
             "license": "BSD-3-Clause",
             "dependencies": {
                 "randombytes": "^2.1.0"
@@ -13820,7 +13762,6 @@
             "version": "0.5.21",
             "resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.5.21.tgz",
             "integrity": "sha512-uBHU3L3czsIyYXKX88fdrGovxdSCoTGDRZ6SYXtSRxLZUzHg5P/66Ht6uoUlHu9EZod+inXhKo3qQgwXUT/y1w==",
-            "dev": true,
             "license": "MIT",
             "dependencies": {
                 "buffer-from": "^1.0.0",
@@ -13831,7 +13772,6 @@
             "version": "0.6.1",
             "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
             "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
-            "dev": true,
             "license": "BSD-3-Clause",
             "engines": {
                 "node": ">=0.10.0"
@@ -14240,7 +14180,6 @@
             "version": "2.2.1",
             "resolved": "https://registry.npmjs.org/tapable/-/tapable-2.2.1.tgz",
             "integrity": "sha512-GNzQvQTOIP6RyTfE2Qxb8ZVlNmw0n88vp1szwWRimP02mnTsx3Wtn5qRdqY9w2XduFNUgvOwhNnQsjwCp+kqaQ==",
-            "dev": true,
             "license": "MIT",
             "engines": {
                 "node": ">=6"
@@ -14250,7 +14189,6 @@
             "version": "5.24.0",
             "resolved": "https://registry.npmjs.org/terser/-/terser-5.24.0.tgz",
             "integrity": "sha512-ZpGR4Hy3+wBEzVEnHvstMvqpD/nABNelQn/z2r0fjVWGQsN3bpOLzQlqDxmb4CDZnXq5lpjnQ+mHQLAOpfM5iw==",
-            "dev": true,
             "license": "BSD-2-Clause",
             "dependencies": {
                 "@jridgewell/source-map": "^0.3.3",
@@ -14269,7 +14207,6 @@
             "version": "5.3.9",
             "resolved": "https://registry.npmjs.org/terser-webpack-plugin/-/terser-webpack-plugin-5.3.9.tgz",
             "integrity": "sha512-ZuXsqE07EcggTWQjXUj+Aot/OMcD0bMKGgF63f7UxYcu5/AJF53aIpK1YoP5xR9l6s/Hy2b+t1AM0bLNPRuhwA==",
-            "dev": true,
             "license": "MIT",
             "dependencies": {
                 "@jridgewell/trace-mapping": "^0.3.17",
@@ -14304,7 +14241,6 @@
             "version": "27.5.1",
             "resolved": "https://registry.npmjs.org/jest-worker/-/jest-worker-27.5.1.tgz",
             "integrity": "sha512-7vuh85V5cdDofPyxn58nrPjBktZo0u9x1g8WtjQol+jZDaE+fhN+cIvTj11GndBnMnyfrUOG1sZQxCdjKh+DKg==",
-            "dev": true,
             "license": "MIT",
             "dependencies": {
                 "@types/node": "*",
@@ -14319,7 +14255,6 @@
             "version": "3.1.1",
             "resolved": "https://registry.npmjs.org/schema-utils/-/schema-utils-3.1.1.tgz",
             "integrity": "sha512-Y5PQxS4ITlC+EahLuXaY86TXfR7Dc5lw294alXOq86JAHCihAIZfqv8nNCWvaEJvaC51uN9hbLGeV0cFBdH+Fw==",
-            "dev": true,
             "license": "MIT",
             "dependencies": {
                 "@types/json-schema": "^7.0.8",
@@ -14338,7 +14273,6 @@
             "version": "8.1.1",
             "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-8.1.1.tgz",
             "integrity": "sha512-MpUEN2OodtUzxvKQl72cUF7RQ5EiHsGvSsVG0ia9c5RbWGL2CI4C7EpPS8UTBIplnlzZiNuV56w+FuNxy3ty2Q==",
-            "dev": true,
             "license": "MIT",
             "dependencies": {
                 "has-flag": "^4.0.0"
@@ -14354,7 +14288,6 @@
             "version": "2.20.3",
             "resolved": "https://registry.npmjs.org/commander/-/commander-2.20.3.tgz",
             "integrity": "sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ==",
-            "dev": true,
             "license": "MIT"
         },
         "node_modules/test-exclude": {
@@ -14879,7 +14812,6 @@
             "version": "5.26.5",
             "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-5.26.5.tgz",
             "integrity": "sha512-JlCMO+ehdEIKqlFxk6IfVoAUVmgz7cU7zD/h9XZ0qzeosSHmUJVOzSQvvYSYWXkFXC+IfLKSIffhv0sVZup6pA==",
-            "dev": true,
             "license": "MIT"
         },
         "node_modules/unicode-canonical-property-names-ecmascript": {
@@ -14971,7 +14903,6 @@
             "version": "4.4.1",
             "resolved": "https://registry.npmjs.org/uri-js/-/uri-js-4.4.1.tgz",
             "integrity": "sha512-7rKUyy33Q1yc98pQ1DAmLtwX109F7TIfWlW1Ydo8Wl1ii1SeHieeh0HHfPeL2fMXK6z0s8ecKs9frCuLJvndBg==",
-            "dev": true,
             "license": "BSD-2-Clause",
             "dependencies": {
                 "punycode": "^2.1.0"
@@ -15041,7 +14972,6 @@
             "version": "2.4.0",
             "resolved": "https://registry.npmjs.org/watchpack/-/watchpack-2.4.0.tgz",
             "integrity": "sha512-Lcvm7MGST/4fup+ifyKi2hjyIAwcdI4HRgtvTpIUxBRhB+RFtUh8XtDOxUfctVCnhVi+QQj49i91OyvzkJl6cg==",
-            "dev": true,
             "license": "MIT",
             "dependencies": {
                 "glob-to-regexp": "^0.4.1",
@@ -15071,7 +15001,6 @@
             "version": "5.89.0",
             "resolved": "https://registry.npmjs.org/webpack/-/webpack-5.89.0.tgz",
             "integrity": "sha512-qyfIC10pOr70V+jkmud8tMfajraGCZMBWJtrmuBymQKCrLTRejBI8STDp1MCyZu/QTdZSeacCQYpYNQVOzX5kw==",
-            "dev": true,
             "license": "MIT",
             "dependencies": {
                 "@types/eslint-scope": "^3.7.3",
@@ -15190,11 +15119,18 @@
                 "node": ">=10.0.0"
             }
         },
+        "node_modules/webpack-shell-plugin-next": {
+            "version": "2.3.1",
+            "resolved": "https://registry.npmjs.org/webpack-shell-plugin-next/-/webpack-shell-plugin-next-2.3.1.tgz",
+            "integrity": "sha512-+ozr/BcsuPh2R6j4oxmu9qJCInhhDCQ+Lb/sSUNHuXjoGj+myxxZyjucHze+K9dCoIo22gAoK1yuCP/gSnpUNg==",
+            "peerDependencies": {
+                "webpack": "^5.18.0"
+            }
+        },
         "node_modules/webpack-sources": {
             "version": "3.2.3",
             "resolved": "https://registry.npmjs.org/webpack-sources/-/webpack-sources-3.2.3.tgz",
             "integrity": "sha512-/DyMEOrDgLKKIG0fmvtz+4dUX/3Ghozwgm6iPp8KRhvn+eQf9+Q7GWxVNMk3+uCPWfdXYC4ExGBckIXdFEfH1w==",
-            "dev": true,
             "license": "MIT",
             "engines": {
                 "node": ">=10.13.0"
@@ -15204,14 +15140,12 @@
             "version": "1.0.4",
             "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.4.tgz",
             "integrity": "sha512-2JwWnHK9H+wUZNorf2Zr6ves96WHoWDJIftkcxPKsS7Djta6Zu519LarhRNljPXkpsZR2ZMwNCPeW7omW07BJw==",
-            "dev": true,
             "license": "MIT"
         },
         "node_modules/webpack/node_modules/acorn": {
             "version": "8.8.2",
             "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.8.2.tgz",
             "integrity": "sha512-xjIYgE8HBrkpd/sJqOGNspf8uHG+NOHGOw6a/Urj8taM2EXfdNAH2oFcPeIFfsv3+kz/mJrS5VuMqbNLjCa2vw==",
-            "dev": true,
             "license": "MIT",
             "bin": {
                 "acorn": "bin/acorn"
@@ -15224,7 +15158,6 @@
             "version": "1.9.0",
             "resolved": "https://registry.npmjs.org/acorn-import-assertions/-/acorn-import-assertions-1.9.0.tgz",
             "integrity": "sha512-cmMwop9x+8KFhxvKrKfPYmN6/pKTYYHBqLa0DfvVZcKMJWNyWLnaqND7dx/qn66R7ewM1UX5XMaDVP5wlVTaVA==",
-            "dev": true,
             "license": "MIT",
             "peerDependencies": {
                 "acorn": "^8"
@@ -15234,7 +15167,6 @@
             "version": "4.19.1",
             "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.19.1.tgz",
             "integrity": "sha512-u2tbbG5PdKRTUoctO3NBD8FQ5HdPh1ZXPHzp1rwaa5jTc+RV9/+RlWiAIKmjRPQF+xbGM9Kklj5bZQFa2s/38A==",
-            "dev": true,
             "license": "MIT",
             "dependencies": {
                 "caniuse-lite": "^1.0.30001286",
@@ -15258,7 +15190,6 @@
             "version": "1.0.30001294",
             "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001294.tgz",
             "integrity": "sha512-LiMlrs1nSKZ8qkNhpUf5KD0Al1KCBE3zaT7OLOwEkagXMEDij98SiOovn9wxVGQpklk9vVC/pUSqgYmkmKOS8g==",
-            "dev": true,
             "license": "CC-BY-4.0",
             "funding": {
                 "type": "opencollective",
@@ -15269,14 +15200,12 @@
             "version": "1.4.31",
             "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.31.tgz",
             "integrity": "sha512-t3XVQtk+Frkv6aTD4RRk0OqosU+VLe1dQFW83MDer78ZD6a52frgXuYOIsLYTQiH2Lm+JB2OKYcn7zrX+YGAiQ==",
-            "dev": true,
             "license": "ISC"
         },
         "node_modules/webpack/node_modules/node-releases": {
             "version": "2.0.1",
             "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.1.tgz",
             "integrity": "sha512-CqyzN6z7Q6aMeF/ktcMVTzhAHCEpf8SOarwpzpf8pNBY2k5/oM34UHldUwp8VKI7uxct2HxSRdJjBaZeESzcxA==",
-            "dev": true,
             "license": "MIT"
         },
         "node_modules/which": {

--- a/package.json
+++ b/package.json
@@ -4,8 +4,6 @@
     "description": "Unofficial ShaderToy Chrome Extension to visualize sound of any page.",
     "main": "index.js",
     "scripts": {
-        "predev": "npm run build_shader_list",
-        "prebuild": "npm run build_shader_list",
         "build": "webpack --config webpack.prod.js",
         "dev": "webpack -w --config webpack.dev.js",
         "test": "jest --config=jest.config.js",
@@ -75,6 +73,7 @@
         "react": "^18.2.0",
         "react-dom": "^18.2.0",
         "three": "^0.159.0",
-        "webextension-polyfill": "^0.10.0"
+        "webextension-polyfill": "^0.10.0",
+        "webpack-shell-plugin-next": "^2.3.1"
     }
 }

--- a/src/buildShaderList.js
+++ b/src/buildShaderList.js
@@ -39,9 +39,14 @@ console.log(`Processing dir '${fullDirPath}'...`);
 const fullFileList = listFilesSync(fullDirPath);
 console.log(`Found ${fullFileList.length} files`);
 
+const currentDate = new Date();
+const dateJson = currentDate.toJSON();
 const formattedFiles = fullFileList.map(formatFileInfo);
-
+const output = {
+  lastModified: dateJson,
+  shaders: formattedFiles
+}
 const outFile = `${directory}/list.json`;
-fs.writeFileSync(outFile, JSON.stringify(formattedFiles, null, 2));
+fs.writeFileSync(outFile, JSON.stringify(output, null, 2));
 console.log(`Wrote file ${outFile}`);
 

--- a/src/content/AnalyzerMesh.tsx
+++ b/src/content/AnalyzerMesh.tsx
@@ -50,7 +50,7 @@ export const AnalyzerMesh = ({ analyser, canvas, shaderObject, speedDivider } : 
     const matRef = useRef<ShaderMaterial>(null);
 
     const loadFragmentShader = async () => {
-        console.log(`loading shader with name: ${shaderObject.shaderName}`);
+        console.log(`loading shader with name: ${shaderObject.shaderName}, and metaData: ${shaderObject.metaData}`);
         const material = matRef.current as ShaderMaterial;
         const loadedFragmentShader = await fetchFragmentShader(shaderObject.shaderName);
         console.log(`loadedShaderLen: ${loadedFragmentShader.length}, material: ${material}`);

--- a/src/helpers/shaderActions.ts
+++ b/src/helpers/shaderActions.ts
@@ -7,10 +7,10 @@ export const fetchFragmentShader = async (name: string) => {
     return res.text()
 }
 
-export const loadShaderList = async () : Promise<ShaderObject[]> => {
+export const loadShaderList = async () : Promise<ShaderCatalog> => {
     const res = await fetch(browser.runtime.getURL(`shaders/list.json`), {
         cache: "no-cache",
     })
     const result = await res.json();
-    return result as ShaderObject[];
+    return result as ShaderCatalog;
 }

--- a/src/helpers/types.ts
+++ b/src/helpers/types.ts
@@ -21,3 +21,9 @@ type ShaderObject = {
     shaderName: string;
     metaData?: any;
 }
+
+type ShaderCatalog = {
+    shaders: ShaderObject[];
+    lastModified: Date;
+}
+

--- a/src/options/Options.tsx
+++ b/src/options/Options.tsx
@@ -16,7 +16,7 @@ const Options: React.FC = () => {
     // Synced states
     const [shaderIndex, setShaderIndex] = useChromeStorageLocal(STATE_SHADERINDEX, 0);
     const [showPreview, setShowPreview] = useChromeStorageLocal(STATE_SHOWPREVIEW, false);
-    const [shaderList, setShaderList] = useChromeStorageLocal<ShaderObject[]>(STATE_SHADERLIST, []);
+    const [shaderCatalog] = useChromeStorageLocal<ShaderCatalog>(STATE_SHADERLIST, { shaders: [], lastModified: new Date(0) });
     const [speedDivider, setSpeedDivider] = useChromeStorageLocal(SETTINGS_SPEEDDIVIDER, 25);
     const [playRandomShader, setPlayRandomShader] = useChromeStorageLocal(SETTINGS_RANDOMIZE_SHADERS, true);
 
@@ -73,7 +73,7 @@ const Options: React.FC = () => {
                 <div className="w-11 h-6 bg-gray-200 peer-focus:outline-none peer-focus:ring-4 peer-focus:ring-blue-300 dark:peer-focus:ring-blue-800 rounded-full peer dark:bg-gray-700 peer-checked:after:translate-x-full rtl:peer-checked:after:-translate-x-full peer-checked:after:border-white after:content-[''] after:absolute after:top-[2px] after:start-[2px] after:bg-white after:border-gray-300 after:border after:rounded-full after:h-5 after:w-5 after:transition-all dark:border-gray-600 peer-checked:bg-blue-600"></div>
                 <span className="ms-3 text-sm font-medium text-gray-900 dark:text-gray-300">Show Preview (experimental):</span>
             </label>
-            {showPreview && <><p className="my-4 text-lg text-gray-500">Preview ({shaderList[shaderIndex].shaderName})</p><video ref={videoElement} className="max-w-96 max-h-96 rounded-lg" playsInline autoPlay muted/></>}
+            {showPreview && <><p className="my-4 text-lg text-gray-500">Preview ({shaderCatalog.shaders[shaderIndex].shaderName})</p><video ref={videoElement} className="max-w-96 max-h-96 rounded-lg" playsInline autoPlay muted/></>}
             
             <p className="my-4 text-lg text-gray-500">Options</p>
             <div className="rounded-lg p-4 shadow-lg select-none">
@@ -113,7 +113,7 @@ const Options: React.FC = () => {
             <p className="my-4 text-lg text-gray-500">Shader List</p>
             <div className="flex flex-wrap">
                 <ul>
-                    {shaderList.map((itemShader: ShaderObject, index: number) => (
+                    {shaderCatalog.shaders.map((itemShader: ShaderObject, index: number) => (
                         <li key={index}>
                             <div
                                 className={`h-10 px-5 m-2 text-white font-medium transition-colors duration-150 bg-indigo-700 rounded-lg focus:shadow-outline hover:bg-indigo-800`}

--- a/src/workers/randomizeShaderWorker.ts
+++ b/src/workers/randomizeShaderWorker.ts
@@ -29,7 +29,8 @@ export class RandomizeShaderContoller {
     }
 
     private selectRandomShader() {
-        const shaderList = this.workerState.shaderList;
+        const catalog = this.workerState.shaderCatalog;
+        const shaderList = catalog.shaders;
         if (shaderList.length == 0) {
             return;
         }

--- a/src/workers/visualizerController.ts
+++ b/src/workers/visualizerController.ts
@@ -7,8 +7,8 @@ import { setStorage } from "@src/storage/storage";
 // Controls the visualisation
 export class VisualizerController {
     workerState: WorkerState;
-    public get shaderList() {
-        return this.workerState.shaderList;
+    public get shaderCatalog() {
+        return this.workerState.shaderCatalog;
     }
 
     constructor(workerState: WorkerState) {
@@ -25,20 +25,20 @@ export class VisualizerController {
                 return;
             }
 
-            const shaderList = this.workerState.shaderList;
+            const shaderCatalog = this.workerState.shaderCatalog;
             const shaderIndex = this.workerState.shaderIndex;
 
             switch (msg.command) {
                 case PREV_SHADER:
                     let previousShaderIndex = shaderIndex - 1;
                     if (previousShaderIndex < 0) { // loop around
-                        previousShaderIndex = shaderList.length - 1;
+                        previousShaderIndex = shaderCatalog.shaders.length - 1;
                     }
                     this.setShader(previousShaderIndex);
                 break;
                 case NEXT_SHADER:
                     let nextShaderIndex = shaderIndex + 1;
-                    if (nextShaderIndex == shaderList.length) { // loop around
+                    if (nextShaderIndex == shaderCatalog.shaders.length) { // loop around
                         nextShaderIndex = 0;
                     }
                     this.setShader(nextShaderIndex); 
@@ -49,7 +49,7 @@ export class VisualizerController {
     }
 
     setShader(index: number) {
-        if (index < 0 || index >= this.shaderList.length) {
+        if (index < 0 || index >= this.shaderCatalog.shaders.length) {
             return;
         }
         setStorage(STATE_SHADERINDEX, index);

--- a/webpack.common.js
+++ b/webpack.common.js
@@ -1,4 +1,5 @@
 const path = require("path");
+const WebpackShellPluginNext = require('webpack-shell-plugin-next');
 
 module.exports = {
     entry: {
@@ -11,6 +12,18 @@ module.exports = {
         path: path.join(__dirname, "dist/js"),
         filename: "[name].js",
     },
+    plugins: [
+        new WebpackShellPluginNext({
+            onBuildStart:{
+                scripts: ['npm run build_shader_list'],
+                blocking: true,
+                parallel: false
+              }, 
+              dev: false,
+              safe: false,
+              logging: true
+        })
+    ],
     module: {
         rules: [
             {
@@ -50,5 +63,8 @@ module.exports = {
             "@src": path.resolve(__dirname, "src/"),
             three: path.resolve('./node_modules/three')
         },
+    },
+    watchOptions: {
+        ignored: '**/list.json',
     },
 };

--- a/yarn.lock
+++ b/yarn.lock
@@ -6820,12 +6820,17 @@ webpack-merge@^5.7.3:
     clone-deep "^4.0.1"
     wildcard "^2.0.0"
 
+webpack-shell-plugin-next@^2.3.1:
+  version "2.3.1"
+  resolved "https://registry.npmjs.org/webpack-shell-plugin-next/-/webpack-shell-plugin-next-2.3.1.tgz"
+  integrity sha512-+ozr/BcsuPh2R6j4oxmu9qJCInhhDCQ+Lb/sSUNHuXjoGj+myxxZyjucHze+K9dCoIo22gAoK1yuCP/gSnpUNg==
+
 webpack-sources@^3.2.3:
   version "3.2.3"
   resolved "https://registry.npmjs.org/webpack-sources/-/webpack-sources-3.2.3.tgz"
   integrity sha512-/DyMEOrDgLKKIG0fmvtz+4dUX/3Ghozwgm6iPp8KRhvn+eQf9+Q7GWxVNMk3+uCPWfdXYC4ExGBckIXdFEfH1w==
 
-webpack@^5.0.0, webpack@^5.1.0, webpack@^5.89.0, webpack@>=5, webpack@5.x.x:
+webpack@^5.0.0, webpack@^5.1.0, webpack@^5.18.0, webpack@^5.89.0, webpack@>=5, webpack@5.x.x:
   version "5.89.0"
   resolved "https://registry.npmjs.org/webpack/-/webpack-5.89.0.tgz"
   integrity sha512-qyfIC10pOr70V+jkmud8tMfajraGCZMBWJtrmuBymQKCrLTRejBI8STDp1MCyZu/QTdZSeacCQYpYNQVOzX5kw==


### PR DESCRIPTION
This PR implements periodic polling of a new version of the shader list (now called catalog).

Unfortunately, this was needed as we moved the state to the service worker and were not able to reload our content pages to fetch new shader changes.

At the moment, this polling mechanism only works when deployed from a development environment (ie. loaded an unpacked extension).

Bonus: This is now effectively a shader hot reload mechanism!



https://github.com/ArthurTent/ShaderAmp/assets/9072397/0ef56971-4f8f-4017-bfc1-f143fb1905a4


